### PR TITLE
Made textSection of imageCard visible in mobile view

### DIFF
--- a/CSS Image Preview Card/style.css
+++ b/CSS Image Preview Card/style.css
@@ -150,7 +150,7 @@ a {
     }
 
     .image-card .column {
-        flex: 100%;
+        flex: 1;
         max-width: 100%;
     }
 


### PR DESCRIPTION
The text Section of the card was not visible in mobile view, 
changed style.css files  flex value to 1 and made it visible,
responsiveness can be checked for the screen width from 570px 